### PR TITLE
提高桌面端可访问性

### DIFF
--- a/.postcssrc.cjs
+++ b/.postcssrc.cjs
@@ -4,19 +4,19 @@ module.exports = {
     autoprefixer: {
       overrideBrowserslist: ['Android 4.1', 'iOS 7.1', 'Chrome > 31', 'ff > 31', 'ie >= 8']
     },
-    'postcss-px-to-viewport': {
-      unitToConvert: 'px', // 要转化的单位
+    'postcss-mobile-forever': {
+      rootSelector: '#app', // 根节点，用于居中
       viewportWidth: 375, // UI设计稿的宽度
+      maxDisplayWidth: 560, // 最大宽度
+      disableLandscape: true, // 禁止生成横屏媒体查询
+      disableDesktop: true, // 禁止生成桌面端媒体查询
       unitPrecision: 6, // 转换后的精度，即小数点位数
       propList: ['*'], // 指定转换的css属性的单位，*代表全部css属性的单位都进行转换
-      viewportUnit: 'vw', // 指定需要转换成的视窗单位，默认vw
-      fontViewportUnit: 'vw', // 指定字体需要转换成的视窗单位，默认vw
+      mobileUnit: 'vw', // 指定需要转换成的视窗单位，默认vw
       selectorBlackList: ['wrap'], // 指定不转换为视窗单位的类名，
-      minPixelValue: 1, // 默认值1，小于或等于1px则不进行转换
-      mediaQuery: true, // 是否在媒体查询的css代码中也进行转换，默认false
-      replace: true, // 是否转换后直接更换属性值
-      exclude: [/node_modules/], // 设置忽略文件，用正则做目录名匹配
-      landscape: false // 是否处理横屏情况
+      valueBlackList: ['1px solid'], // 指定不转换的值
+      exclude: [/node_modules[\\/](?!vant)/], // 设置忽略文件，用正则做目录名匹配
+      rootContainingBlockSelectorList: ['.van-tabbar', '.float-btn'] // 指定长度属性基于根包含块的选择器（选择器样式是基于 position: fixed 的）
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ npm run dev
 
 ### <span id="viewport">⚙️ viewport 适配</span>
 
-- postcss-px-to-viewport 文档： <https://github.com/evrone/postcss-px-to-viewport/blob/master/README_CN.md>
+- postcss-mobile-forever 文档： <https://github.com/wswmsword/postcss-mobile-forever>
 
 ```
-npm i -D postcss-px-to-viewport autoprefixer
+npm i -D postcss postcss-mobile-forever autoprefixer
 ```
 
 ```javascript
@@ -87,19 +87,19 @@ module.exports = {
     autoprefixer: {
       overrideBrowserslist: ['Android 4.1', 'iOS 7.1', 'Chrome > 31', 'ff > 31', 'ie >= 8']
     },
-    'postcss-px-to-viewport': {
-      unitToConvert: 'px', // 要转化的单位
+    'postcss-mobile-forever': {
+      rootSelector: '#app', // 根节点，用于居中
       viewportWidth: 375, // UI设计稿的宽度
+      maxDisplayWidth: 560, // 最大宽度
+      disableLandscape: true, // 禁止生成横屏媒体查询
+      disableDesktop: true, // 禁止生成桌面端媒体查询
       unitPrecision: 6, // 转换后的精度，即小数点位数
       propList: ['*'], // 指定转换的css属性的单位，*代表全部css属性的单位都进行转换
-      viewportUnit: 'vw', // 指定需要转换成的视窗单位，默认vw
-      fontViewportUnit: 'vw', // 指定字体需要转换成的视窗单位，默认vw
+      mobileUnit: 'vw', // 指定需要转换成的视窗单位，默认vw
       selectorBlackList: ['wrap'], // 指定不转换为视窗单位的类名，
-      minPixelValue: 1, // 默认值1，小于或等于1px则不进行转换
-      mediaQuery: true, // 是否在媒体查询的css代码中也进行转换，默认false
-      replace: true, // 是否转换后直接更换属性值
-      exclude: [/node_modules/], // 设置忽略文件，用正则做目录名匹配
-      landscape: false // 是否处理横屏情况
+      valueBlackList: ['1px solid'], // 指定不转换的值
+      exclude: [/node_modules[\\/](?!vant)/], // 设置忽略文件，用正则做目录名匹配
+      rootContainingBlockSelectorList: ['.van-tabbar', '.float-btn'] // 指定长度属性基于根包含块的选择器（选择器样式是基于 position: fixed 的）
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "plop": "^3.1.2",
         "postcss": "^8.4.23",
         "postcss-loader": "^7.2.4",
-        "postcss-px-to-viewport": "^1.1.1",
+        "postcss-mobile-forever": "^3.4.2",
         "typescript": "^5.0.2",
         "vite": "^4.3.0",
         "vite-plugin-mock": "^3.0.0",
@@ -5104,6 +5104,15 @@
         }
       }
     },
+    "node_modules/postcss-mobile-forever": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/postcss-mobile-forever/-/postcss-mobile-forever-3.4.2.tgz",
+      "integrity": "sha512-77uJ+G18TM4xjpODK/+LGzWkRmIOnNXJDOIQySuCbY/KIZqxvxD7igEmYNsn0ha/e2LypGQ3vwHeeJxV2Kq7nQ==",
+      "dev": true,
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
     "node_modules/postcss-prefix-selector": {
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/postcss-prefix-selector/-/postcss-prefix-selector-1.16.0.tgz",
@@ -5111,16 +5120,6 @@
       "dev": true,
       "peerDependencies": {
         "postcss": ">4 <9"
-      }
-    },
-    "node_modules/postcss-px-to-viewport": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-px-to-viewport/-/postcss-px-to-viewport-1.1.1.tgz",
-      "integrity": "sha512-2x9oGnBms+e0cYtBJOZdlwrFg/mLR4P1g2IFu7jYKvnqnH/HLhoKyareW2Q/x4sg0BgklHlP1qeWo2oCyPm8FQ==",
-      "dev": true,
-      "dependencies": {
-        "object-assign": ">=4.0.1",
-        "postcss": ">=5.0.2"
       }
     },
     "node_modules/postcss-value-parser": {
@@ -11032,22 +11031,19 @@
         "semver": "^7.3.8"
       }
     },
+    "postcss-mobile-forever": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/postcss-mobile-forever/-/postcss-mobile-forever-3.4.2.tgz",
+      "integrity": "sha512-77uJ+G18TM4xjpODK/+LGzWkRmIOnNXJDOIQySuCbY/KIZqxvxD7igEmYNsn0ha/e2LypGQ3vwHeeJxV2Kq7nQ==",
+      "dev": true,
+      "requires": {}
+    },
     "postcss-prefix-selector": {
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/postcss-prefix-selector/-/postcss-prefix-selector-1.16.0.tgz",
       "integrity": "sha512-rdVMIi7Q4B0XbXqNUEI+Z4E+pueiu/CS5E6vRCQommzdQ/sgsS4dK42U7GX8oJR+TJOtT+Qv3GkNo6iijUMp3Q==",
       "dev": true,
       "requires": {}
-    },
-    "postcss-px-to-viewport": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-px-to-viewport/-/postcss-px-to-viewport-1.1.1.tgz",
-      "integrity": "sha512-2x9oGnBms+e0cYtBJOZdlwrFg/mLR4P1g2IFu7jYKvnqnH/HLhoKyareW2Q/x4sg0BgklHlP1qeWo2oCyPm8FQ==",
-      "dev": true,
-      "requires": {
-        "object-assign": ">=4.0.1",
-        "postcss": ">=5.0.2"
-      }
     },
     "postcss-value-parser": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "plop": "^3.1.2",
     "postcss": "^8.4.23",
     "postcss-loader": "^7.2.4",
-    "postcss-px-to-viewport": "^1.1.1",
+    "postcss-mobile-forever": "^3.4.2",
     "typescript": "^5.0.2",
     "vite": "^4.3.0",
     "vite-plugin-mock": "^3.0.0",

--- a/src/styles/index.less
+++ b/src/styles/index.less
@@ -6,3 +6,9 @@
   -ms-user-select:none; /* IE浏览器 */
   user-select:none; /* 用户是否能够选中文本 */
 }
+
+#app {
+  width: 100vw;
+  min-height: 100vh;
+  position: relative;
+}


### PR DESCRIPTION
你好 ZYCHOOO，我最近写了个插件 [postcss-mobile-forever](https://github.com/wswmsword/postcss-mobile-forever)，它可以转换有最大宽度的伸缩移动端视图，解决了 px-to-viewport 在大屏上字体很大的问题，我最近在推广这个插件，搜到了你的项目。

如果您有意向做桌面端优化，欢迎合并～

下面是我用了插件之后的截图：

<table>
	<tr>
		<td><img src="https://github.com/ZYCHOOO/vue3ts-h5-template/assets/26893092/00e4c912-9417-46dd-8b11-82af61c938d6" alt="移动端的展示效果" /></td>
		<td><img src="https://github.com/ZYCHOOO/vue3ts-h5-template/assets/26893092/c38ded47-f8d5-41b6-bac9-7d98bccf3be3" alt="移动端横屏的展示效果" /></td>
	</tr>
	<tr>
		<td><img src="https://github.com/ZYCHOOO/vue3ts-h5-template/assets/26893092/cd82aa5f-b548-49c5-bf77-304028e4b8a1" alt="插件的桌面端的展示效果" /></td>
		<td><img src="https://github.com/ZYCHOOO/vue3ts-h5-template/assets/26893092/f5dc66bc-dac9-4198-a712-72428860b5b7" alt="插件的桌面端的展示效果" /></td>
	</tr>
</table>
